### PR TITLE
Remove irc notifications from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,13 +53,3 @@ before_script:
 
 script:
   - php tests/phpunit/phpunit.php
-
-notifications:
-  email: false
-  irc:
-    channels:
-      - "chat.freenode.net#mediawiki-core"
-      - "chat.freenode.net#mediawiki-feed"
-    on_success: change
-    on_failure: change
-    skip_join: true


### PR DESCRIPTION
Remove IRC build status notifications from .travis.yml to avoid spamming.

From #mediawiki-core on 2015-02-11T17:34Z:
```
[17:43]  <travis-ci>	jehovahsays/mediawiki#4 (master - 5e5fa17 : jehovahsays): The build passed.
[17:43]  <travis-ci>	Change view : https://github.com/jehovahsays/mediawiki/compare/422faf56c9f3...5e5fa173f136
[17:43]  <travis-ci>	Build details : http://travis-ci.org/jehovahsays/mediawiki/builds/50376765
```